### PR TITLE
Allow ThisExpressions in the LHS of AttributeExpression

### DIFF
--- a/lib/format/lol/parser.py
+++ b/lib/format/lol/parser.py
@@ -564,7 +564,8 @@ class Parser():
     def get_attr_expression(self, idref, ws_post_id):
         if not isinstance(idref, (ast.ParenthesisExpression,
                                   ast.CallExpression,
-                                  ast.Identifier)):
+                                  ast.Identifier,
+                                  ast.ThisExpression)):
             raise ParserError()
         if self.content[1] == '[':
             self.content = self.content[2:]


### PR DESCRIPTION
{{ ~..attr }} should be a valid syntax
